### PR TITLE
Use generator expression in Network.__iter__

### DIFF
--- a/src/ipcalc.py
+++ b/src/ipcalc.py
@@ -523,7 +523,7 @@ class Network(IP):
         192.168.114.2
         192.168.114.3
         '''
-        for ip in [IP(long(self)+x) for x in xrange(0, self.size())]:
+        for ip in (IP(long(self)+x) for x in xrange(0, self.size())):
             yield ip
 
     def has_key(self, ip):


### PR DESCRIPTION
Use a generator expression in Network.**iter** instead of a list
comprehension in order to conserve memory, and additionally make it so
that the full list doesn't have to be generated before the method can
begin returning entries.
