### PR TITLE
IPv6 and IPv4 address hex/octects that are 0 fail without the "<=" operator.

### DIFF
--- a/src/ipcalc.py
+++ b/src/ipcalc.py
@@ -302,7 +302,7 @@ class IP(object):
             if len(q) > 4:
                 raise ValueError, "%r: IPv4 address invalid: more than 4 bytes" % dq
             for x in q:
-                if not 0 < int(x) < 255:
+                if not 0 <= int(x) < 255:
                     raise ValueError, "%r: IPv4 address invalid: bytes should be between 0 and 255" % dq
             while len(q) < 4:
                 q.insert(1, '0')


### PR DESCRIPTION
Verified with the IPv6 address example in the README file.

<pre>
>>> subnet = ipcalc.Network('2001:beef:babe::/48')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "ipcalc.py", line 163, in __init__
    self.ip = self._dqtoi(ip)
  File "ipcalc.py", line 289, in _dqtoi
    raise ValueError, "%r: IPv6 address invalid: hextets should be between 0x0000 and 0xffff" % dq
ValueError: '2001:beef:babe::': IPv6 address invalid: hextets should be between 0x0000 and 0xffff

>>> subnet = ipcalc.Network('127.0.0.1/8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "ipcalc.py", line 163, in __init__
    self.ip = self._dqtoi(ip)
  File "ipcalc.py", line 306, in _dqtoi
    raise ValueError, "%r: IPv4 address invalid: bytes should be between 0 and 255" % dq
ValueError: '127.0.0.1': IPv4 address invalid: bytes should be between 0 and 255
</pre>
