### PR TITLE
Address/mask hex/octet checks exclude the top and bottom of the range

### DIFF
--- a/src/ipcalc.py
+++ b/src/ipcalc.py
@@ -285,7 +285,7 @@ class IP(object):
             for h in hx:
                 if len(h) < 4:
                     h = '%04x' % int(h, 16)
-                if not 0 < int(h, 16) < 0xffff:
+                if not 0 <= int(h, 16) <= 0xffff:
                     raise ValueError, "%r: IPv6 address invalid: hextets should be between 0x0000 and 0xffff" % dq
                 ip += h
             self.v = 6
@@ -302,7 +302,7 @@ class IP(object):
             if len(q) > 4:
                 raise ValueError, "%r: IPv4 address invalid: more than 4 bytes" % dq
             for x in q:
-                if not 0 < int(x) < 255:
+                if not 0 <= int(x) <= 255:
                     raise ValueError, "%r: IPv4 address invalid: bytes should be between 0 and 255" % dq
             while len(q) < 4:
                 q.insert(1, '0')


### PR DESCRIPTION
IPv6 address/mask hextets can contain 0x0 and 0xffff
IPv4 address/mask octets can contain 0 and 255

Twinshadow's Pull Request only fixes the problem for one of these cases.
