### PR TITLE
Remove explicit multiline error string concatenation

### DIFF
--- a/src/ipcalc.py
+++ b/src/ipcalc.py
@@ -270,10 +270,10 @@ class IP(object):
             elif len(hx) < 8:
                 # No :: in address
                 if not '' in hx:
-                    raise ValueError('%s: IPv6 address invalid: ' +
+                    raise ValueError('%s: IPv6 address invalid: '
                         'compressed format malformed' % dq)
                 elif not (dq.startswith('::') or dq.endswith('::')) and len([x for x in hx if x == '']) > 1:
-                    raise ValueError('%s: IPv6 address invalid: ' +
+                    raise ValueError('%s: IPv6 address invalid: '
                         'compressed format malformed' % dq)
                 ix = hx.index('')
                 px = len(hx[ix + 1:])
@@ -282,7 +282,7 @@ class IP(object):
             elif dq.endswith('::'):
                 pass
             elif '' in hx:
-                raise ValueError('%s: IPv6 address invalid: ' +
+                raise ValueError('%s: IPv6 address invalid: '
                     'compressed format detected in full notation' % dq())
             ip = ''
             hx = [x == '' and '0' or x for x in hx]
@@ -290,7 +290,7 @@ class IP(object):
                 if len(h) < 4:
                     h = '%04x' % int(h, 16)
                 if not 0 <= int(h, 16) <= 0xffff:
-                    raise ValueError('%r: IPv6 address invalid: ' +
+                    raise ValueError('%r: IPv6 address invalid: '
                         'hexlets should be between 0x0000 and 0xffff' % dq)
                 ip += h
             self.v = 6
@@ -305,11 +305,11 @@ class IP(object):
             q = dq.split('.')
             q.reverse()
             if len(q) > 4:
-                raise ValueError('%s: IPv4 address invalid: ' +
+                raise ValueError('%s: IPv4 address invalid: '
                     'more than 4 bytes' % dq)
             for x in q:
                 if not 0 <= int(x) <= 255:
-                    raise ValueError('%s: IPv4 address invalid: ' +
+                    raise ValueError('%s: IPv4 address invalid: '
                         'bytes should be between 0 and 255' % dq)
             while len(q) < 4:
                 q.insert(1, '0')
@@ -394,7 +394,7 @@ class IP(object):
             elif long(self) & 0x20020000000000000000000000000000L:
                 return IP((long(self) - 0x20020000000000000000000000000000L) >> 80, version=4)
             else:
-                return ValueError('%s: IPv6 address is not IPv4 compatible, ' +
+                return ValueError('%s: IPv6 address is not IPv4 compatible, '
                     'nor an 6-to-4 IP' % self.dq)
 
     @classmethod


### PR DESCRIPTION
There are a few places that had strings broken onto multiple lines using string interpolation AND concatenation.  This results in errors like the one below:

```
Python 2.7.1 (r271:86832, Jun 16 2011, 16:59:05) 
[GCC 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2335.15.00)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import ipcalc
>>> ipcalc.Network("256.0.0.0")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jwineinger/dev/8b/lib/python2.7/site-packages/ipcalc.py", line 166, in __init__
    self.ip = self._dqtoi(ip)
  File "/Users/jwineinger/dev/8b/lib/python2.7/site-packages/ipcalc.py", line 313, in _dqtoi
    'bytes should be between 0 and 255' % dq)
TypeError: not all arguments converted during string formatting
```

I simply removed the concat operator -- the "+" -- so that python implicitly joins the lines together and then applies the string formatting.
