### PR TITLE
Change condition in check_collision. I think there may be a typo in the second comparison.

### DIFF
--- a/ipcalc.py
+++ b/ipcalc.py
@@ -590,7 +590,7 @@ class Network(IP):
         '''
         other = Network(other)
         return self.network_long() <= other.network_long() <= self.broadcast_long() or \
-            other.network_long() <= self.network_long() <= self.broadcast_long()
+            other.network_long() <= self.network_long() <= other.broadcast_long()
 
     def __contains__(self, ip):
         '''


### PR DESCRIPTION
Hi Wijnand,

Adding a print of check_collision results to the test ouput gives for example:
# 

ip address: 192.168.114.42
to ipv6...: 2002:c0a8:722a:0000:0000:0000:0000:0000
ip version: 4
ip info...: PRIVATE RFC1918
subnet....: 23
num ip's..: 512
integer...: 3232264746
hex.......: c0a8722a
netmask...: 255.255.254.0
network...: 192.168.114.0
broadcast.: 192.168.115.255
first host: 192.168.114.1
reverse...: 1.114.168.192.in-addr.arpa
last host.: 192.168.115.254
reverse...: 254.115.168.192.in-addr.arpa
ipcalc.py:583: DeprecationWarning: Network.in_network is deprecated, use check_collision in stead
  DeprecationWarning)
192.168.0.1 in network:  False
192.168.0.1 check collision:  **True**
192.168.114.128 in network:  True
192.168.114.128 check collision:  True
10.0.0.1 in network:  False
10.0.0.1 check collision:  **True**

Happy to be proved wrong!

Cheers
Chris
