### PR TITLE
Add __repr__ for easier reading of printed IPs.

### DIFF
--- a/ipcalc.py
+++ b/ipcalc.py
@@ -351,6 +351,11 @@ class IP(object):
                         self.mask,
                         self.v)
 
+    def __hash__(self):
+        return hash(self.to_tuple())
+
+    hash = __hash__
+
     def __int__(self):
         return int(self.ip)
 


### PR DESCRIPTION
This adds [eval-like `__repr__`](http://stackoverflow.com/a/2626364/543431) strings to `IP()` and `Network()`, making it a lot easier to compare IP's when printed.

```
<ipcalc.IP object at 0x...>
```

vs

```
IP('127.0.0.1', mask=32, version=4)
```
