### PR TITLE
More canonical and print formatting

### DIFF
--- a/ipcalc.py
+++ b/ipcalc.py
@@ -677,10 +677,8 @@ class Network(IP):
         >>> for ip in Network('192.168.114.0/30'):
         ...     print str(ip)
         ...
-        192.168.114.0
         192.168.114.1
         192.168.114.2
-        192.168.114.3
         '''
 
         curr = long(self.host_first())


### PR DESCRIPTION
Continuing from PR #28...

This does:

``` python
In [5]: print repr(IP("1.2.3.4/29"))
IP('1.2.3.4/29')

In [6]: print repr(IP("1.2.3.4/32"))
IP('1.2.3.4')

In [7]: print repr(IP("1.2.3.4/29"))
IP('1.2.3.4/29')

In [8]: print repr(Network("1.2.3.4/29"))
Network('1.2.3.4/29')

In [9]: print str(IP("1.2.3.4/29"))
1.2.3.4

In [10]: print str(Network("1.2.3.4/29"))
1.2.3.4/29
```

Any suggestions?
