### PR TITLE
Update setup dependency for "six" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ Documentation is available from http://ipcalc.rtfd.org/
       author_email='maze@pyth0n.org',
       url='https://github.com/tehmaze/ipcalc/',
       py_modules=['ipcalc'],
+      install_requires=['six'],
       )


### PR DESCRIPTION
Updated setup dependency for "six" package. `pip` (pypi) package currently fails to work as-is.