### PR TITLE
Added Network.wildcard() support to IPv6 addresses

### DIFF
--- a/ipcalc.py
+++ b/ipcalc.py
@@ -608,7 +608,7 @@ class Network(IP):
         if self.version() == 4:
             return IP(MAX_IPV4 - self.netmask_long(), version=self.version())
         else:
-            raise ValueError('IPv6 does not support wildcard masks.')
+            return IP(MAX_IPV6 - self.netmask_long(), version=self.version())
 
     def network(self):
         """

--- a/test.py
+++ b/test.py
@@ -86,8 +86,7 @@ class TestSuite(unittest.TestCase):
         self.assertTrue(str(net.netmask()) == 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')
         self.assertTrue(net.version() == 6)
         self.assertTrue(str(net.network()) == '0123:0000:0000:0000:0000:0000:0000:0000')
-        with self.assertRaises(ValueError):
-            net.wildcard()
+        self.assertTrue(str(net.wildcard()) == '0000:0000:0000:0000:0000:0000:0000:0000')
         self.assertTrue(str(net.broadcast()) == '0123:0000:0000:0000:0000:0000:0000:0000')
         self.assertFalse('123:456::' in net)
         self.assertTrue('123::' in net)
@@ -109,8 +108,7 @@ class TestSuite(unittest.TestCase):
         self.assertTrue(int(net) == 0x42)
         self.assertTrue(net.hex().lower() == '00000000000000000000000000000042')
         self.assertTrue(str(net.netmask()) == 'ffff:ffff:ffff:ffff:0000:0000:0000:0000')
-        with self.assertRaises(ValueError):
-            net.wildcard()
+        self.assertTrue(str(net.wildcard()) == '0000:0000:0000:0000:ffff:ffff:ffff:ffff')
         self.assertTrue(net.version() == 6)
         self.assertTrue(str(net.network()) == '0000:0000:0000:0000:0000:0000:0000:0000')
         self.assertTrue(str(net.broadcast()) == '0000:0000:0000:0000:ffff:ffff:ffff:ffff')
@@ -136,8 +134,7 @@ class TestSuite(unittest.TestCase):
         self.assertTrue(int(net) == 0x2001deadbeef0001c01dc01a00000000)
         self.assertTrue(net.hex().lower() == '2001deadbeef0001c01dc01a00000000')
         self.assertTrue(str(net.netmask()) == 'ffff:ffff:ffff:0000:0000:0000:0000:0000')
-        with self.assertRaises(ValueError):
-            net.wildcard()
+        self.assertTrue(str(net.wildcard()) == '0000:0000:0000:ffff:ffff:ffff:ffff:ffff')
         self.assertTrue(net.version() == 6)
         self.assertTrue(str(net.network()) == '2001:dead:beef:0000:0000:0000:0000:0000')
         self.assertTrue(str(net.broadcast()) == '2001:dead:beef:ffff:ffff:ffff:ffff:ffff')
@@ -159,8 +156,7 @@ class TestSuite(unittest.TestCase):
         self.assertTrue(int(net) == 0x2001deadbeef0001c01dc01a00000000)
         self.assertTrue(net.hex().lower() == '2001deadbeef0001c01dc01a00000000')
         self.assertTrue(str(net.netmask()) == 'ffff:ffff:ffff:0000:0000:0000:0000:0000')
-        with self.assertRaises(ValueError):
-            net.wildcard()
+        self.assertTrue(str(net.wildcard()) == '0000:0000:0000:ffff:ffff:ffff:ffff:ffff')
         self.assertTrue(net.version() == 6)
         self.assertTrue(str(net.network()) == '2001:dead:beef:0000:0000:0000:0000:0000')
         self.assertTrue(str(net.broadcast()) == '2001:dead:beef:ffff:ffff:ffff:ffff:ffff')


### PR DESCRIPTION
I've added Network.wildcard() support to IPv6 addresses.