### PR TITLE
Fix "TypeError: 'str' object is not callable" in ipcalc.py

### DIFF
--- a/ipcalc.py
+++ b/ipcalc.py
@@ -293,7 +293,7 @@ class IP(object):
             pass
         elif '' in hx:
             raise ValueError('%s: IPv6 address invalid: '
-                             'compressed format detected in full notation' % dq())
+                             'compressed format detected in full notation' % dq)
         ip = ''
         hx = [x == '' and '0' or x for x in hx]
         for h in hx:


### PR DESCRIPTION
I use ipcalc in my work project and in line 296 catch Error: "TypeError: 'str' object is not callable" (in autotests). Fix this by remove call of string.
![2024-05-07_20-32](https://github.com/tehmaze/ipcalc/assets/31971067/f4d5ef90-4bfb-4c6e-a8dd-a7c9dd7137f4)
